### PR TITLE
Fix unevaluated class of wrapper of configurable option.

### DIFF
--- a/app/views/admin/configurables/show.html.erb
+++ b/app/views/admin/configurables/show.html.erb
@@ -7,7 +7,7 @@
     <%= form_tag(admin_configurable_path, :method => :put) do -%>
         <%- @keys.each do |key| -%>
             <%- options = Configurable.defaults[key] -%>
-            <div class="#{options[:type] = 'boolean' ? '' : 'input-field'}">
+            <div class="<%= options[:type] = 'boolean' ? '' : 'input-field' -%>">
               <%- if options[:type] != 'boolean' %>
                   <%= label_tag key, options[:name] %>
               <%- end -%>


### PR DESCRIPTION
Renders `<div class="boolean">` or `<div class="input-field">...</div>`
instead of `<div class="#{options[:type] = 'boolean' ? '' : 'input-field'}">...</div>`